### PR TITLE
3 implement cpu interrupts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,17 @@ version = "0.1.0"
 dependencies = [
  "bootloader_api",
  "embedded-graphics",
+ "lazy_static",
  "x86_64",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
 ]
 
 [[package]]
@@ -888,6 +898,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,6 +601,9 @@ dependencies = [
  "bootloader_api",
  "embedded-graphics",
  "lazy_static",
+ "pc-keyboard",
+ "pic8259",
+ "spin",
  "x86_64",
 ]
 
@@ -688,6 +691,21 @@ name = "parking"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
+name = "pc-keyboard"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6f2d937e3b8d63449b01401e2bae4041bc9dd1129c2e3e0d239407cf6635ac"
+
+[[package]]
+name = "pic8259"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb844b5b01db1e0b17938685738f113bfc903846f18932b378bc0eabfa40e194"
+dependencies = [
+ "x86_64",
+]
 
 [[package]]
 name = "pin-project"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -12,6 +12,9 @@ bench = false
 bootloader_api = "0.11.2"
 embedded-graphics = "0.8.1"
 x86_64 = "0.14.2"
+pic8259 = "0.10.1"
+spin = "0.5.2"
+pc-keyboard = "0.5.0"
 
 [dependencies.lazy_static]
 version = "1.4.0"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -12,3 +12,7 @@ bench = false
 bootloader_api = "0.11.2"
 embedded-graphics = "0.8.1"
 x86_64 = "0.14.2"
+
+[dependencies.lazy_static]
+version = "1.4.0"
+features = ["spin_no_std"]

--- a/kernel/src/gdt.rs
+++ b/kernel/src/gdt.rs
@@ -1,0 +1,49 @@
+use x86_64::VirtAddr;
+use x86_64::structures::tss::TaskStateSegment;
+use x86_64::structures::gdt::{
+    Descriptor,
+    GlobalDescriptorTable,
+    SegmentSelector,
+};
+
+use lazy_static::lazy_static;
+
+pub const DOUBLE_FAULT_IST_INDEX: u16 = 0;
+
+lazy_static! {
+    static ref TSS: TaskStateSegment = {
+        let mut tss = TaskStateSegment::new();
+        tss.interrupt_stack_table[DOUBLE_FAULT_IST_INDEX as usize] = {
+            const STACK_SIZE: usize = 4096 * 5;
+            static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
+
+            let stack_start = VirtAddr::from_ptr(unsafe { &STACK });
+            let stack_end = stack_start + STACK_SIZE;
+            stack_end
+        };
+        tss
+    };
+
+    static ref GDT: (GlobalDescriptorTable, Selectors) = {
+        let mut gdt = GlobalDescriptorTable::new();
+        let code_selector = gdt.add_entry(Descriptor::kernel_code_segment());
+        let tss_selector = gdt.add_entry(Descriptor::tss_segment(&TSS));
+        (gdt, Selectors { code_selector, tss_selector })
+    };
+}
+
+struct Selectors {
+    code_selector: SegmentSelector,
+    tss_selector: SegmentSelector,
+}
+
+pub fn init() {
+    use x86_64::instructions::tables::load_tss;
+    use x86_64::instructions::segmentation::{CS, Segment};
+
+    GDT.0.load();
+    unsafe {
+        CS::set_reg(GDT.1.code_selector);
+        load_tss(GDT.1.tss_selector);
+    }
+}

--- a/kernel/src/interrupts.rs
+++ b/kernel/src/interrupts.rs
@@ -5,10 +5,19 @@ use x86_64::structures::idt::{
 
 use lazy_static::lazy_static;
 
+use crate::gdt;
+
 lazy_static! {
     static ref IDT: InterruptDescriptorTable = {
         let mut idt = InterruptDescriptorTable::new();
         idt.breakpoint.set_handler_fn(breakpoint_handler);
+        unsafe {
+            idt.
+                double_fault.
+                set_handler_fn(double_fault_handler).
+                set_stack_index(gdt::DOUBLE_FAULT_IST_INDEX);
+        }
+
         idt
     };
 }
@@ -19,4 +28,11 @@ pub fn init_idt() {
 
 extern "x86-interrupt" fn breakpoint_handler(_stack_frame: InterruptStackFrame) {
     // println!("EXCEPTION: BREAKPOINT\n{:#?}", stack_frame);
+}
+
+extern "x86-interrupt" fn double_fault_handler(
+    stack_frame: InterruptStackFrame,
+    _error_code: u64,
+) -> ! {
+    panic!("EXCEPTION: DOUBLE FAULT\n{:#?}", stack_frame);
 }

--- a/kernel/src/interrupts.rs
+++ b/kernel/src/interrupts.rs
@@ -3,9 +3,18 @@ use x86_64::structures::idt::{
     InterruptStackFrame,
 };
 
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref IDT: InterruptDescriptorTable = {
+        let mut idt = InterruptDescriptorTable::new();
+        idt.breakpoint.set_handler_fn(breakpoint_handler);
+        idt
+    };
+}
+
 pub fn init_idt() {
-    let mut idt = InterruptDescriptorTable::new();
-    idt.breakpoint.set_handler_fn(breakpoint_handler);
+    IDT.load();
 }
 
 extern "x86-interrupt" fn breakpoint_handler(_stack_frame: InterruptStackFrame) {

--- a/kernel/src/interrupts.rs
+++ b/kernel/src/interrupts.rs
@@ -3,6 +3,9 @@ use x86_64::structures::idt::{
     InterruptStackFrame,
 };
 
+use pic8259::ChainedPics;
+use spin;
+
 use lazy_static::lazy_static;
 
 use crate::gdt;
@@ -17,9 +20,35 @@ lazy_static! {
                 set_handler_fn(double_fault_handler).
                 set_stack_index(gdt::DOUBLE_FAULT_IST_INDEX);
         }
+        idt[InterruptIndex::Timer.as_usize()].set_handler_fn(timer_interrupt_handler);
+        idt[InterruptIndex::Keyboard.as_usize()].set_handler_fn(keyboard_interrupt_handler);
 
         idt
     };
+}
+
+pub const PIC_1_OFFSET: u8 = 32;
+pub const PIC_2_OFFSET: u8 = PIC_1_OFFSET + 8;
+
+pub static PICS: spin::Mutex<ChainedPics> = spin::Mutex::new(unsafe {
+    ChainedPics::new(PIC_1_OFFSET, PIC_2_OFFSET)
+});
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum InterruptIndex {
+    Timer = PIC_1_OFFSET,
+    Keyboard,
+}
+
+impl InterruptIndex {
+    fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    fn as_usize(self) -> usize {
+        usize::from(self.as_u8())
+    }
 }
 
 pub fn init_idt() {
@@ -35,4 +64,59 @@ extern "x86-interrupt" fn double_fault_handler(
     _error_code: u64,
 ) -> ! {
     panic!("EXCEPTION: DOUBLE FAULT\n{:#?}", stack_frame);
+}
+
+extern "x86-interrupt" fn timer_interrupt_handler(
+    _stack_frame: InterruptStackFrame
+) {
+    // print!(".");
+
+    unsafe {
+        PICS.
+            lock().
+            notify_end_of_interrupt(InterruptIndex::Timer.as_u8());
+    }
+}
+
+extern "x86-interrupt" fn keyboard_interrupt_handler(
+    _stack_frame: InterruptStackFrame
+) {
+    use pc_keyboard::{
+        DecodedKey,
+        HandleControl,
+        Keyboard,
+        ScancodeSet1,
+        layouts,
+    };
+
+    use spin::Mutex;
+
+    use x86_64::instructions::port::Port;
+
+    lazy_static! {
+        static ref KEYBOARD: Mutex<Keyboard<layouts::Us104Key, ScancodeSet1>> = Mutex::new(Keyboard::new(
+            layouts::Us104Key,
+            ScancodeSet1,
+            HandleControl::Ignore
+        ));
+    }
+
+    let mut keyboard = KEYBOARD.lock();
+    let mut port = Port::new(0x60);
+
+    let scancode: u8 = unsafe { port.read() };
+    if let Ok(Some(key_event)) = keyboard.add_byte(scancode) {
+        if let Some(key) = keyboard.process_keyevent(key_event) {
+            // match key {
+            //     DecodedKey::Unicode(character) => print!("{}", character),
+            //     DecodedKey::RawKey(key) => print!("{:?}", key),
+            // }
+        }
+    }
+
+    unsafe {
+        PICS.
+            lock().
+            notify_end_of_interrupt(InterruptIndex::Keyboard.as_u8());
+    }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -5,8 +5,10 @@
 
 pub mod framebuffer;
 pub mod interrupts;
+pub mod gdt;
 pub mod writer;
 
 pub fn init() {
+    gdt::init();
     interrupts::init_idt();
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,8 +1,12 @@
 #![feature(abi_x86_interrupt)]
 #![no_std]
 
-extern crate alloc;
+// extern crate alloc;
 
 pub mod framebuffer;
 pub mod interrupts;
 pub mod writer;
+
+pub fn init() {
+    interrupts::init_idt();
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -11,4 +11,14 @@ pub mod writer;
 pub fn init() {
     gdt::init();
     interrupts::init_idt();
+    unsafe {
+        interrupts::PICS.lock().initialize()
+    };
+    x86_64::instructions::interrupts::enable();
+}
+
+pub fn hlt_loop() -> ! {
+    loop {
+        x86_64::instructions::hlt();
+    }
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -68,6 +68,10 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
 
     kernel::init();
 
+    // unsafe {
+    //     *(0xdeadbeef as *mut u8) = 42;
+    // };
+
     // x86_64::instructions::interrupts::int3();
 
     loop {}

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -74,7 +74,7 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
 
     // x86_64::instructions::interrupts::int3();
 
-    loop {}
+    kernel::hlt_loop();
 }
 
 #[panic_handler]

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -24,47 +24,51 @@ mod framebuffer;
 bootloader_api::entry_point!(kernel_main);
 
 fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
-    if let Some(framebuffer) = boot_info.framebuffer.as_mut() {
-        let info = framebuffer.info();
-        let height = info.height;
-        let stride = info.stride;
-        let width = info.width;
-        let magnitude = 1.0 / (width as f32 / 255.0);
-        let area = stride as f32 * height as f32;
+    // if let Some(framebuffer) = boot_info.framebuffer.as_mut() {
+    //     let info = framebuffer.info();
+    //     let height = info.height;
+    //     let stride = info.stride;
+    //     let width = info.width;
+    //     let magnitude = 1.0 / (width as f32 / 255.0);
+    //     let area = stride as f32 * height as f32;
+    //
+    //     for x in 0..width {
+    //         for y in 0..height {
+    //             let scale = magnitude * 255.0;
+    //             let col = x as f32 / 255.0;
+    //             let row = y as f32 / 255.0;
+    //             let red = (col * scale) as u8;
+    //             let green = (row * scale) as u8;
+    //             let depth = y as f32 * stride as f32;
+    //             let blue = (((depth + x as f32) / area) * 255.0) as u8;
+    //
+    //             framebuffer::set_pixel_in(
+    //                 framebuffer,
+    //                 framebuffer::Position { x, y },
+    //                 framebuffer::Color { red, green, blue },
+    //             );
+    //         }
+    //     }
+    //     let mut display: Display = Display::new(framebuffer);
+    //
+    //     let character_style = MonoTextStyle::new(&FONT_10X20, RgbColor::WHITE);
+    //
+    //     let text = "Hello World, I'm HOS!";
+    //     let x = 5;
+    //     let y = display.size().height as i32 - (character_style.font.character_size.height as f32 * 0.5) as i32;
+    //     let position = Point::new(x, y);
+    //     Text::with_alignment(
+    //         text,
+    //         position,
+    //         character_style,
+    //         Alignment::Left,
+    //     )
+    //     .draw(&mut display).unwrap();
+    // }
 
-        for x in 0..width {
-            for y in 0..height {
-                let scale = magnitude * 255.0;
-                let col = x as f32 / 255.0;
-                let row = y as f32 / 255.0;
-                let red = (col * scale) as u8;
-                let green = (row * scale) as u8;
-                let depth = y as f32 * stride as f32;
-                let blue = (((depth + x as f32) / area) * 255.0) as u8;
+    kernel::init();
 
-                framebuffer::set_pixel_in(
-                    framebuffer,
-                    framebuffer::Position { x, y },
-                    framebuffer::Color { red, green, blue },
-                );
-            }
-        }
-        let mut display: Display = Display::new(framebuffer);
-
-        let character_style = MonoTextStyle::new(&FONT_10X20, RgbColor::WHITE);
-
-        let text = "Hello World, I'm HOS!";
-        let x = 5;
-        let y = display.size().height as i32 - (character_style.font.character_size.height as f32 * 0.5) as i32;
-        let position = Point::new(x, y);
-        Text::with_alignment(
-            text,
-            position,
-            character_style,
-            Alignment::Left,
-        )
-        .draw(&mut display).unwrap();
-    }
+    // x86_64::instructions::interrupts::int3();
 
     loop {}
 }


### PR DESCRIPTION
This branch implements these three posts from the excellent Rust OS tutorial series:

1. [CPU Exceptions](https://os.phil-opp.com/cpu-exceptions/)
2. [Double Faults](https://os.phil-opp.com/double-fault-exceptions/)
3. [Hardware Interrupts](https://os.phil-opp.com/hardware-interrupts/)

If you check this out, you won't see any of the console output from those posts as I haven't implemented the print macros yet - I'm doing the posts a bit out of order 😅